### PR TITLE
Keep pkcs11-proxy on README.md coherent with image

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > **SoftHSM has been developed for development purposes only. Don't use in production!**
 
 A multi-arch Docker image to run a virtual HSM (Hardware Security Module) network service based on [SoftHSM2](https://github.com/softhsm/SoftHSMv2) and
-[pkcs11-proxy](https://github.com/SUNET/pkcs11-proxy/).
+[pkcs11-proxy](https://github.com/smallstep/pkcs11-proxy).
 
 Automatically rebuilt **weekly** to include the latest OS security fixes.
 


### PR DESCRIPTION
The pkcs11-proxy lib referenced in the README is https://github.com/SUNET/pkcs11-proxy/

However, the one currently used is https://github.com/smallstep/pkcs11-proxy/